### PR TITLE
Fix Hyperlink Typo in Multipose Detection with TensorFlow Example

### DIFF
--- a/pages/v1/examples.mdx
+++ b/pages/v1/examples.mdx
@@ -9,7 +9,7 @@ You can start by running some of the following application examples. They contai
 
 - [Add Wattermark](/v1/examples/wattermark)
 - [Cats Recognition](/v1/examples/cats)
-- [Multipose detection with TensorFlow](/v1/examples/pose)
+- [Multipose detection with TensorFlow](/v1/examples/tf-pose)
 - [YOLOv8 object detection](/v1/examples/yolov8)
 - [Object detection using the ONNX Runtime](/v1/examples/onnx-yolo)
 - [Candy filter with ONNX Runtime](/v1/examples/onnx-candy)


### PR DESCRIPTION
**Title:**
[PR] Fix Hyperlink Typo in Multipose Detection with TensorFlow Example

**Description:**
**Changes Made:**
- Corrected the hyperlink typo in the "Multipose Detection with TensorFlow" example in the documentation's "Examples" category.
- Updated the hyperlink from [https://www.pipeless.ai/docs/docs/v1/examples/pose](https://www.pipeless.ai/docs/docs/v1/examples/pose) to [https://www.pipeless.ai/docs/docs/v1/examples/tf-pose](https://www.pipeless.ai/docs/docs/v1/examples/tf-pose).

**Checklist:**
- [x] Verified and fixed the hyperlink typo.

**Related Issues:**
- Fixes #9 
