### PR TITLE
Update benchmark.mdx

### DIFF
--- a/pages/v1/benchmark.mdx
+++ b/pages/v1/benchmark.mdx
@@ -41,3 +41,11 @@ The following defines the stream that was used in all the cases:
 ## Nvidia Jetson Xavier NX, Jetpack 4.6
 
 TODO
+
+## Jetson AGX Orin Developer Kit, Jetpack 5.1.2
+* Pre-process avg. time: `0ms`
+* Process (inference) avg. time: `49ms`
+* Post-process avg. time: `1.52ms`
+* Ultralytics reported inference time : `9.6ms`
+* Hypothetical ideal FPS: `89` (`1/ ((9.6 + 1.52)/1000)`)
+* Actual FPS : `19` (`1/ ((49 + 1.52)/1000)`)


### PR DESCRIPTION
Yolov8 TensorRT model benchmark on Jetson AGX Orin , Jetpack 5.1.2.


The source file which were used to calculate the average are attached. 

[yolo_timing.csv](https://github.com/user-attachments/files/16633396/yolo_timing.csv)
[inference_time_measured.csv](https://github.com/user-attachments/files/16633399/inference_time_measured.csv)
